### PR TITLE
Switch back to dependence on Source SDK Base 2006

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ The map source files of Fortress Forever
 
 1. **Install Source SDK**
   * In Steam, go to the Library tab and select *Tools* from the dropdown
-  * Find Source SDK in the list and install it
+  * Find *Source SDK* in the list and install it
+2. **Install Source SDK Base**
+Note: Fortress Forever redistributes Source SDK Base, but there are issues when Hammer does not load appid 215; see issue #4
+  * In Steam, go to the Library tab and select *Tools* from the dropdown
+  * Find *Source SDK Base 2006* in the list and install it
 2. **Setup Source SDK**
   * Run Source SDK once (it will install some misc files and set the `sourcesdk` environment variable for you). Close it once it is finished.
   * Run [`setup.bat`](setup.bat)

--- a/README.md
+++ b/README.md
@@ -6,14 +6,13 @@ The map source files of Fortress Forever
 1. **Install Source SDK**
   * In Steam, go to the Library tab and select *Tools* from the dropdown
   * Find *Source SDK* in the list and install it
-2. **Install Source SDK Base**
-Note: Fortress Forever redistributes Source SDK Base, but there are issues when Hammer does not load appid 215; see issue #4
+2. **Install Source SDK Base 2006** (this ideally wouldn't be necessary, [see issue #4](https://github.com/fortressforever/fortressforever-maps/issues/4))
   * In Steam, go to the Library tab and select *Tools* from the dropdown
   * Find *Source SDK Base 2006* in the list and install it
-2. **Setup Source SDK**
+3. **Setup Source SDK**
   * Run Source SDK once (it will install some misc files and set the `sourcesdk` environment variable for you). Close it once it is finished.
   * Run [`setup.bat`](setup.bat)
-3. **Launch Hammer**
+4. **Launch Hammer**
   * Open Source SDK
   * Select *Source Engine 2006* as the *Engine Version* and *Fortress Forever* as the *Current Game*
   * Double click *Hammer Editor* under the *Applications* heading

--- a/setup.bat
+++ b/setup.bat
@@ -28,6 +28,8 @@ set Ep1BinDir=%sourcesdk%\bin\ep1\bin
 set ConfigFile=%Ep1BinDir%\GameConfig.txt
 set SchemeDir=%Ep1BinDir%\resource
 set SchemeFile=%SchemeDir%\SourceScheme.res
+set GameInfoDir=%GameDir%/sdk
+set GameInfoFile=%GameInfoDir%/gameinfo.txt
 
 echo(
 echo Writing "%ConfigFile%"...
@@ -63,6 +65,32 @@ echo 		}
 echo 	}
 echo }
 ) >"%ConfigFile%"
+echo  -^> Done
+
+IF NOT EXIST "%GameInfoDir%" mkdir "%GameInfoDir%"
+echo(
+echo Writing "%GameInfoFile%"...
+(
+echo "GameInfo"
+echo {
+echo 	game	"Fortress Forever"
+echo 	title	"Fortress Forever"
+echo 	name	"Fortress Forever"
+echo 	type multiplayer_only
+echo(
+echo 	FileSystem
+echo 	{
+echo 		SteamAppId				215
+echo 		ToolsAppId				211
+echo 		SearchPaths
+echo 		{
+echo 			Game				^|gameinfo_path^|..\FortressForever
+echo 			Game				^|gameinfo_path^|..\hl2
+echo 			Game				^|gameinfo_path^|..\platform
+echo 		}
+echo 	}
+echo }
+) > "%GameInfoFile%"
 echo  -^> Done
 
 :: Need a SourceScheme.res in bin/ep1/bin/resource so that Hammer doesn't throw

--- a/setup.bat
+++ b/setup.bat
@@ -39,7 +39,7 @@ echo 	"Games"
 echo 	{
 echo 		"Fortress Forever"
 echo 		{
-echo 			"GameDir"		"%ModDir%"
+echo 			"GameDir"		"%GameDir%/sdk"
 echo 			"hammer"
 echo 			{
 echo 				"GameData0"		"%ModDir%/fortressforever.fgd"


### PR DESCRIPTION
- See #4
- Needs a common/Fortress Forever/sdk/gameinfo.txt in the FF install

~~Shouldn't be merged until the next patch so that we can include the necessary sdk/gameinfo.txt.~~ EDIT: Now writes the necessary gameinfo.txt
